### PR TITLE
Use schemeless URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <link rel="stylesheet" type="text/css" href="ledstrip.css" />
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.10.1/jquery.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.10.1/jquery.js"></script>
     <script type="text/javascript" src="rAF.js"></script>
     <script type="text/javascript" src="ledstrip.js"></script>
     <script type="text/javascript" src="ws2812.js"></script>


### PR DESCRIPTION
Avoid browser security problems by using a schemeless URL for jQuery.